### PR TITLE
Fixed underflow bug when checking max buffer.

### DIFF
--- a/src/engine/dynamic_graphs/graphchi_dynamicgraph_engine.hpp
+++ b/src/engine/dynamic_graphs/graphchi_dynamicgraph_engine.hpp
@@ -1,5 +1,4 @@
 
-
 /**
  * @file
  * @author  Aapo Kyrola <akyrola@cs.cmu.edu>
@@ -295,7 +294,7 @@ namespace graphchi {
                 usleep(1000000);
                 return false;
             }
-            if (added_edges - last_commit > 1.2 * max_edge_buffer) {
+            if (added_edges > last_commit && added_edges - last_commit > 1.2 * max_edge_buffer) {
                 logstream(LOG_INFO) << "Over 20% of max buffer... hold on...." << std::endl;
                 usleep(1000000); // Sleep 1 sec
                 return false;


### PR DESCRIPTION
When running tests I found that "last_commit" could become larger than "added_edges", thus causing an underflow and meaning that the result of the subtraction would always be larger than "1.2 \* max_edge_buffer".

I added in the simple inequality check, but I'm not sure if this is a symptom of a deeper problem.
