### PR TITLE
Fixed typo in regnormal code

### DIFF
--- a/toolkits/collaborative_filtering/als_tensor.cpp
+++ b/toolkits/collaborative_filtering/als_tensor.cpp
@@ -134,7 +134,7 @@ struct ALSVerticesInMemProgram : public GraphChiProgram<VertexDataType, EdgeData
     }
     double regularization = lambda;
     if (regnormal)
-      lambda *= vertex.num_edges();
+      regularization *= vertex.num_edges();
     for(int i=0; i < D; i++) XtX(i,i) += regularization;
 
     // Solve the least squares problem with eigen using Cholesky decomposition

--- a/toolkits/collaborative_filtering/pmf.cpp
+++ b/toolkits/collaborative_filtering/pmf.cpp
@@ -329,7 +329,7 @@ struct PMFVerticesInMemProgram : public GraphChiProgram<VertexDataType, EdgeData
 
     double regularization = lambda;
     if (regnormal)
-      lambda *= vertex.num_edges();
+      regularization *= vertex.num_edges();
     for(int i=0; i < D; i++) XtX(i,i) += regularization;
 
     // Solve the least squares problem with eigen using Cholesky decomposition

--- a/toolkits/collaborative_filtering/sparse_als.cpp
+++ b/toolkits/collaborative_filtering/sparse_als.cpp
@@ -127,7 +127,7 @@ struct ALSVerticesInMemProgram : public GraphChiProgram<VertexDataType, EdgeData
 
     double regularization = lambda;
     if (regnormal)
-      lambda *= vertex.num_edges();
+      regularization *= vertex.num_edges();
     for(int i=0; i < D; i++) XtX(i,i) += regularization;
 
 

--- a/toolkits/collaborative_filtering/wals.cpp
+++ b/toolkits/collaborative_filtering/wals.cpp
@@ -127,7 +127,7 @@ struct WALSVerticesInMemProgram : public GraphChiProgram<VertexDataType, EdgeDat
     }
     double regularization = lambda;
     if (regnormal)
-      lambda *= vertex.num_edges();
+      regularization *= vertex.num_edges();
     for(int i=0; i < D; i++) XtX(i,i) += regularization;
 
     // Solve the least squares problem with eigen using Cholesky decomposition


### PR DESCRIPTION
ALS-Tensor,  PMF, Sparse-ALS and Weighted-ALS all have the same typo in the code responsible for handling the "regnormal" flag. The regularization parameter lambda is incorrectly modified each time a vertex is processed.
