### PR TITLE
Fixed compile error

### DIFF
--- a/src/util/labelanalysis.hpp
+++ b/src/util/labelanalysis.hpp
@@ -166,7 +166,7 @@ void analyze_labels(std::string basefilename, int printtop = 20) {
     std::string outname = basefilename + ".components";
     std::ofstream resf;
     resf.open(outname.c_str());
-    if (resf == NULL) {
+    if (!resf) {
         logstream(LOG_ERROR) << "Could not write label outputfile : " << outname << std::endl;
         return;
     }

--- a/toolkits/graph_analytics/label_analysis.hpp
+++ b/toolkits/graph_analytics/label_analysis.hpp
@@ -157,7 +157,7 @@ void analyze_labels2(std::string base_filename, FILE * pfile, int printtop = 20)
   /* Write output file */
   std::string outname = base_filename + "_components.txt";
   FILE * resf = fopen(outname.c_str(), "w");
-  if (resf == NULL) {
+  if (!resf) {
     logstream(LOG_ERROR) << "Could not write label outputfile : " << outname << std::endl;
     return;
   }


### PR DESCRIPTION
Fixes the following compile error:

```
./src/util/labelanalysis.hpp: In function ‘void analyze_labels(std::__cxx11::string, int)’
./src/util/labelanalysis.hpp:169:14: error: no match for ‘operator==’ (operand types are ‘std::ofstream {aka std::basic_ofstream<char>}’ and ‘long int’)
```