### PR TITLE
fixed connected_components compile error

### DIFF
--- a/src/util/labelanalysis.hpp
+++ b/src/util/labelanalysis.hpp
@@ -166,7 +166,7 @@ void analyze_labels(std::string basefilename, int printtop = 20) {
     std::string outname = basefilename + ".components";
     std::ofstream resf;
     resf.open(outname.c_str());
-    if (resf == NULL) {
+    if (resf.fail()) {
         logstream(LOG_ERROR) << "Could not write label outputfile : " << outname << std::endl;
         return;
     }


### PR DESCRIPTION
I use g++ 7.3.0 and Ubuntu 18.04.
I cloned graphchi-cpp and typed "make".
I saw the following error and fixed the error.

/usr/include/c++/7/bits/stl_pair.h:443:5: note:   template argument deduction/substitution failed:
In file included from /usr/include/dirent.h:245:0,
                 from ./src/preprocessing/conversions.hpp:34,
                 from ./src/graphchi_basic_includes.hpp:54,
                 from example_apps/connectedcomponents.cpp:50:
./src/util/labelanalysis.hpp:169:17: note:   ‘std::ofstream {aka std::basic_ofstream<char>}’ is not derived from ‘const std::pair<_T1, _T2>’
     if (resf == NULL) {
                 ^
Makefile:31: recipe for target 'example_apps/connectedcomponents' failed
make: *** [example_apps/connectedcomponents] Error 1